### PR TITLE
Fixed error when running watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.ts",
   "scripts": {
     "start": "node src/server.ts",
-    "watch": "tsc-watch --esModuleInterop src/server.ts --outDir ./dist --onSuccess 'node ./dist/server.js'",
+    "watch": "tsc-watch --esModuleInterop src/server.ts --outDir ./dist --onSuccess \"node ./dist/server.js\"",
     "test": "jasmine-ts",
     "tsc": "tsc"
   },

--- a/package.json
+++ b/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "storefront_backend",
-  "version": "0.1.0",
-  "description": "",
-  "main": "server.ts",
-  "scripts": {
-    "start": "node src/server.ts",
-    "watch": "tsc-watch --esModuleInterop src/server.ts --outDir ./dist --onSuccess 'node ./dist/server.js'",
-    "test": "jasmine-ts",
-    "tsc": "tsc"
-  },
-  "author": "Udacity",
-  "license": "ISC",
-  "dependencies": {
-    "@types/express": "^4.17.9",
-    "@types/pg": "^7.14.7",
-    "express": "^4.17.1",
-    "body-parser": "^1.19.0",
-    "typescript": "^4.1.3",
-    "pg": "^8.5.1"
-  },
-  "devDependencies": {
-    "@types/jasmine": "^3.6.3",
-    "jasmine": "^3.6.4",
-    "jasmine-spec-reporter": "^6.0.0",
-    "jasmine-ts": "^0.3.0",
-    "ts-node": "^9.1.1",
-    "tsc-watch": "^4.2.9"
-  }
+    "name": "storefront_backend",
+    "version": "0.1.0",
+    "description": "",
+    "main": "server.ts",
+    "scripts": {
+        "start": "node src/server.ts",
+        "watch": "tsc-watch --esModuleInterop src/server.ts --outDir ./dist --onSuccess \"node ./dist/server.js\"",
+        "test": "jasmine-ts",
+        "tsc": "tsc"
+    },
+    "author": "Udacity",
+    "license": "ISC",
+    "dependencies": {
+        "@types/express": "^4.17.9",
+        "@types/pg": "^7.14.7",
+        "express": "^4.17.1",
+        "body-parser": "^1.19.0",
+        "typescript": "^4.1.3",
+        "pg": "^8.5.1"
+    },
+    "devDependencies": {
+        "@types/jasmine": "^3.6.3",
+        "jasmine": "^3.6.4",
+        "jasmine-spec-reporter": "^6.0.0",
+        "jasmine-ts": "^0.3.0",
+        "ts-node": "^9.1.1",
+        "tsc-watch": "^4.2.9"
+    }
 }


### PR DESCRIPTION
Thi PR fixes an error in the starter code when running `npm run watch` (see image attached)

![image](https://user-images.githubusercontent.com/8228498/126420696-f95d3e87-e697-49fc-880a-8a42ae83acdb.png)
