### PR TITLE
Fix types being in  dependencies instead of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "author": "Udacity",
   "license": "ISC",
   "dependencies": {
-    "@types/express": "^4.17.9",
-    "@types/pg": "^7.14.7",
     "express": "^4.17.1",
     "body-parser": "^1.19.0",
     "typescript": "^4.1.3",
     "pg": "^8.5.1"
   },
   "devDependencies": {
+    "@types/express": "^4.17.9",
     "@types/jasmine": "^3.6.3",
+    "@types/pg": "^7.14.7",
     "jasmine": "^3.6.4",
     "jasmine-spec-reporter": "^6.0.0",
     "jasmine-ts": "^0.3.0",


### PR DESCRIPTION
This PR is to fix the package.json and make types be in the right place, dev dependencies. 